### PR TITLE
Bump time upper bound

### DIFF
--- a/uuid.cabal
+++ b/uuid.cabal
@@ -34,7 +34,7 @@ Library
                 hashable (>= 1.1.1.0 && < 1.2.0) || (>= 1.2.1 && < 1.3),
                 network-info == 0.2.*,
                 random >= 1.0.1 && < 1.2,
-                time >= 1.1 && < 1.5
+                time >= 1.1 && < 1.6
 
  Exposed-Modules:
    Data.UUID


### PR DESCRIPTION
Time package got its version 1.5 in September, and UUID seems to build and work just fine with it. This PR bumps the upper bound of `time` to 1.6.
