### PR TITLE
gunfold and gfoldl implementations for instance Data UUID

### DIFF
--- a/uuid-types/Data/UUID/Types/Internal.hs
+++ b/uuid-types/Data/UUID/Types/Internal.hs
@@ -582,7 +582,8 @@ instance Binary UUID where
 -- I want when used with the HStringTemplate library.
 instance Data UUID where
     toConstr uu  = mkConstr uuidType (show uu) [] (error "fixity")
-    gunfold _ _  = error "gunfold"
+    gunfold k z _ = k (k (z UUID))
+    gfoldl k z (UUID a1 a2) = ((z UUID `k` a1) `k` a2)
     dataTypeOf _ = uuidType
 
 uuidType :: DataType


### PR DESCRIPTION
I ran into a situation where a problem I was diagnosing was masked by this call to error "gunfold".  This seems like a harmless enhancement to the instance, unless I'm mistaken.  These definitions are adapted from those generated by DeriveDataTypeable.