### PR TITLE
Switch from Criterion to Gauge

### DIFF
--- a/uuid-types/tests/BenchUUID.hs
+++ b/uuid-types/tests/BenchUUID.hs
@@ -6,7 +6,7 @@
 import           Control.DeepSeq
 import qualified Data.ByteString.Lazy.Internal as BL
 #endif
-import           Criterion.Main
+import           Gauge.Main
 import qualified Data.ByteString.Lazy          as BL
 import qualified Data.HashSet                  as HashSet
 import           Data.Maybe                    (fromJust)

--- a/uuid-types/uuid-types.cabal
+++ b/uuid-types/uuid-types.cabal
@@ -90,5 +90,5 @@ benchmark benchmark
                      , random
                        -- deps w/o inherited constraints
                      , containers >= 0.4   && < 0.6
-                     , criterion  == 1.4.*
+                     , gauge      == 0.2.*
                      , unordered-containers >= 0.2.7 && < 0.3

--- a/uuid/tests/BenchUUID.hs
+++ b/uuid/tests/BenchUUID.hs
@@ -1,4 +1,4 @@
-import Criterion.Main
+import Gauge.Main
 import Data.Char (ord)
 import Data.IORef
 import Data.Word

--- a/uuid/uuid.cabal
+++ b/uuid/uuid.cabal
@@ -91,5 +91,5 @@ benchmark benchmark
                      , base
                      , random
                        -- deps w/o inherited constraints
-                     , criterion              == 1.4.*
+                     , gauge                  == 0.2.*
                      , mersenne-random-pure64 == 0.2.*


### PR DESCRIPTION
This is one piece in the puzzle of achieving GHC 8.10
compatibility. Criterion 1.5 (currently 1.4 is used) would introduce a cyclic
dependency, so using Gauge instead on recommendation
from Simon Jakobi (@sjakobi on GHC Gitlab and Freenode)