### PR TITLE
Allow bytestring-0.11 + hashable-1.3

### DIFF
--- a/uuid-types/uuid-types.cabal
+++ b/uuid-types/uuid-types.cabal
@@ -37,10 +37,10 @@ source-repository head
 Library
     build-depends:     base       >= 4.3     && < 5
                      , binary     >= 0.4     && < 0.9
-                     , bytestring >= 0.9     && < 0.11
+                     , bytestring >= 0.9     && < 0.12
                      , deepseq    >= 1.3     && < 1.5
                      , hashable  (>= 1.1.1.0 && < 1.2)
-                              || (>= 1.2.1   && < 1.3)
+                              || (>= 1.2.1   && < 1.4)
                      , random     >= 1.0.1   && < 1.2
                      , text       >= 1.2.3   && < 1.3
 

--- a/uuid/uuid.cabal
+++ b/uuid/uuid.cabal
@@ -32,7 +32,7 @@ Source-Repository head
 Library
     Build-Depends:     base            >= 4.3      && < 5
                      , binary          >= 0.4      && < 0.9
-                     , bytestring      >= 0.10     && < 0.11
+                     , bytestring      >= 0.10     && < 0.12
                      , cryptohash-sha1 >= 0.11.100 && < 0.12
                      , cryptohash-md5  >= 0.11.100 && < 0.12
                      , entropy         >= 0.3.7    && < 0.5


### PR DESCRIPTION
Tested with
```cabal
packages: uuid-types/
          uuid/

tests: True

constraints:
  bytestring >= 0.11

allow-newer:
  cryptohash-sha1:bytestring,
  cryptohash-md5:bytestring
```

`hashable-1.3` has already been allowed by a Hackage revision, but not mirrored in the repo.