### PR TITLE
Allow random-1.2 and QuickCheck-2.14

### DIFF
--- a/uuid-types/uuid-types.cabal
+++ b/uuid-types/uuid-types.cabal
@@ -41,7 +41,7 @@ Library
                      , deepseq    >= 1.3     && < 1.5
                      , hashable  (>= 1.1.1.0 && < 1.2)
                               || (>= 1.2.1   && < 1.3)
-                     , random     >= 1.0.1   && < 1.2
+                     , random     >= 1.0.1   && < 1.3
                      , text       >= 1.2.3   && < 1.3
 
     exposed-modules:
@@ -69,7 +69,7 @@ test-suite testuuid
                      , binary
                      , bytestring
                        -- deps w/o inherited constraints
-                     , QuickCheck       == 2.11.*
+                     , QuickCheck       >= 2.11 && < 2.15
                      , ghc-byteorder    == 4.11.*
                      , tasty            == 1.0.*
                      , tasty-hunit      == 0.10.*

--- a/uuid/uuid.cabal
+++ b/uuid/uuid.cabal
@@ -37,7 +37,7 @@ Library
                      , cryptohash-md5  >= 0.11.100 && < 0.12
                      , entropy         >= 0.3.7    && < 0.5
                      , network-info    == 0.2.*
-                     , random          >= 1.0.1    && < 1.2
+                     , random          >= 1.0.1    && < 1.3
                      , time            >= 1.1      && < 1.9
                      , text            >= 1.2.3    && < 1.3
                      , uuid-types      >= 1.0.2    && < 2
@@ -73,7 +73,7 @@ Test-Suite testuuid
                      , bytestring
                      , random
                        -- deps w/o inherited constraints
-                     , QuickCheck       == 2.11.*
+                     , QuickCheck       >= 2.11 && < 2.15
                      , tasty            == 1.0.*
                      , tasty-hunit      == 0.10.*
                      , tasty-quickcheck == 0.10.*


### PR DESCRIPTION
This is a conservative approach to unblock `random-1.2`, cf. #53.

Tested with 
```cabal
packages: uuid-types/
          uuid/

tests: True

constraints:
  random >= 1.2
```

`random-1.2` has been already allowed by a Hackage revision for `uuid-types` only.