### PR TITLE
Optimize toByteString and toASCIIBytes

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,3 +13,4 @@ Michael Snoyman
 Bardur Arantsson
 Timo von Holtz
 Oleg Grenrus
+Borys Lykah

--- a/uuid-bench/bench/uuid-types-benchmark.hs
+++ b/uuid-bench/bench/uuid-types-benchmark.hs
@@ -1,11 +1,5 @@
 {-# LANGUAGE CPP #-}
 
-#if !(MIN_VERSION_bytestring(0,10,0))
-{-# OPTIONS_GHC -fno-warn-orphans #-}
--- Needed for NFData instance
-import           Control.DeepSeq
-import qualified Data.ByteString.Lazy.Internal as BL
-#endif
 import           Criterion.Main
 import qualified Data.ByteString.Lazy          as BL
 import qualified Data.HashSet                  as HashSet
@@ -14,13 +8,6 @@ import qualified Data.Set                      as Set
 import qualified Data.UUID.Types               as U
 import           Foreign                       (alloca, peek, poke)
 import           System.Random
-
-#if !(MIN_VERSION_bytestring(0,10,0))
--- orphan
-instance NFData BL.ByteString where
-    rnf BL.Empty        = ()
-    rnf (BL.Chunk _ ts) = rnf ts
-#endif
 
 main :: IO ()
 main = do

--- a/uuid-bench/uuid-bench.cabal
+++ b/uuid-bench/uuid-bench.cabal
@@ -40,19 +40,19 @@ source-repository head
 
 library
   build-depends:
-      base              >=4.9      && <5
-    , binary            >=0.5.1.0  && <0.9
-    , bytestring        >=0.9.2.1  && <0.12
-    , cryptohash-md5    >=0.11.100 && <0.12
-    , cryptohash-sha1   >=0.11.100 && <0.12
-    , deepseq           >=1.3.0.0  && <1.5
-    , entropy           >=0.3.7    && <0.5
-    , hashable          >=1.2.7.0  && <1.5
-    , network-info      >=0.2      && <0.3
-    , random            >=1.1      && <1.3
-    , template-haskell  >=2.7.0.0  && <2.20
-    , text              >=1.2.3.0  && <1.3 || >=2.0 && <2.1
-    , time              >=1.4      && <1.13
+      base              >=4.9       && <5
+    , binary            >=0.5.1.0   && <0.9
+    , bytestring        >=0.10.2.0  && <0.12
+    , cryptohash-md5    >=0.11.100  && <0.12
+    , cryptohash-sha1   >=0.11.100  && <0.12
+    , deepseq           >=1.3.0.0   && <1.5
+    , entropy           >=0.3.7     && <0.5
+    , hashable          >=1.2.7.0   && <1.5
+    , network-info      >=0.2       && <0.3
+    , random            >=1.1       && <1.3
+    , template-haskell  >=2.7.0.0   && <2.21
+    , text              >=1.2.3.0   && <1.3 || >=2.0 && <2.1
+    , time              >=1.4       && <1.13
 
   -- uuid modules
   exposed-modules:

--- a/uuid-types/ChangeLog.md
+++ b/uuid-types/ChangeLog.md
@@ -1,3 +1,8 @@
+## 1.0.5.1
+
+- Optimize and refactor functions `toByteString` (3.7x speed increase) and
+  `toASCIIBytes` (20% speed increase).
+
 ## 1.0.5 (2021-05-03)
 
 - Add (Template Haskell) `Lift UUID` instance

--- a/uuid-types/src/Data/UUID/Types/Internal.hs
+++ b/uuid-types/src/Data/UUID/Types/Internal.hs
@@ -216,10 +216,6 @@ word a b c d =  (fromIntegral a `unsafeShiftL` 24)
             .|. (fromIntegral c `unsafeShiftL`  8)
             .|. (fromIntegral d                  )
 
--- |Extract a Word8 from a Word64. Bytes, high to low, are numbered from 7 to 0,
-byte :: Int -> Word64 -> Word8
-byte i w = fromIntegral (w `shiftR` (i * 8))
-
 -- |Build a Word16 from two Word8 values, presented in big-endian order.
 w8to16 :: Word8 -> Word8 -> Word16
 w8to16 w0s w1s =
@@ -266,11 +262,7 @@ buildFromWords v w0 w1 w2 w3 = fromWords w0 w1' w2' w3
 
 -- |Return the bytes that make up the UUID
 toList :: UUID -> [Word8]
-toList (UUID w0 w1) =
-    [byte 7 w0, byte 6 w0, byte 5 w0, byte 4 w0,
-     byte 3 w0, byte 2 w0, byte 1 w0, byte 0 w0,
-     byte 7 w1, byte 6 w1, byte 5 w1, byte 4 w1,
-     byte 3 w1, byte 2 w1, byte 1 w1, byte 0 w1]
+toList = B.unpack . B.toStrict . toByteString
 
 -- |Construct a UUID from a list of Word8. Returns Nothing if the list isn't
 -- exactly sixteen bytes long
@@ -349,7 +341,7 @@ fromString' s0 = do
                     octet = fromIntegral (16 * digitToInt hi + digitToInt lo)
           hexByte _ = Nothing
 
--- | Convert a UUID into a hypenated string using lower-case letters.
+-- | Convert a UUID into a hyphenated string using lower-case letters.
 -- Example:
 --
 -- >>> toString <$> fromString "550e8400-e29b-41d4-a716-446655440000"

--- a/uuid-types/src/Data/UUID/Types/Internal.hs
+++ b/uuid-types/src/Data/UUID/Types/Internal.hs
@@ -301,11 +301,19 @@ nil = UUID 0 0
 fromByteString :: BL.ByteString -> Maybe UUID
 fromByteString = fromList . BL.unpack
 
+networkOrderUUIDFixedPrim :: BBP.FixedPrim UUID
+networkOrderUUIDFixedPrim = toWords64 BBP.>$< wordFixedPrim
+  where
+    wordFixedPrim :: BBP.FixedPrim (Word64, Word64)
+    wordFixedPrim = BBP.word64BE BBP.>*< BBP.word64BE
+
 -- |Encode a UUID into a 'ByteString' in network order.
 --
 -- This uses the same encoding as the 'Binary' instance.
 toByteString :: UUID -> BL.ByteString
-toByteString = BL.pack . toList
+toByteString uuid = BB.toLazyByteStringWith (BB.untrimmedStrategy 16 BB.defaultChunkSize) mempty builder
+  where
+    builder = BBP.primFixed networkOrderUUIDFixedPrim uuid
 
 -- |If the passed in 'String' can be parsed as a 'UUID', it will be.
 -- The hyphens may not be omitted.

--- a/uuid-types/uuid-types.cabal
+++ b/uuid-types/uuid-types.cabal
@@ -1,6 +1,6 @@
 cabal-version:      1.12
 name:               uuid-types
-version:            1.0.5.1
+version:            1.0.5.2
 copyright:
   (c) 2017-2018 Herbert Valerio Riedel
   (c) 2008-2014 Antoine Latter

--- a/uuid-types/uuid-types.cabal
+++ b/uuid-types/uuid-types.cabal
@@ -50,14 +50,14 @@ source-repository head
 
 library
   build-depends:
-      base              >=4.5     && <5
-    , binary            >=0.5.1.0 && <0.9
-    , bytestring        >=0.9.2.1 && <0.13
-    , deepseq           >=1.3.0.0 && <1.6
-    , hashable          >=1.2.7.0 && <1.5
-    , random            >=1.1     && <1.3
-    , template-haskell  >=2.7.0.0 && <2.22
-    , text              >=1.2.3.0 && <1.3  || >=2.0 && <2.2
+      base              >=4.5      && <5
+    , binary            >=0.5.1.0  && <0.9
+    , bytestring        >=0.10.2.0 && <0.13
+    , deepseq           >=1.3.0.0  && <1.6
+    , hashable          >=1.2.7.0  && <1.5
+    , random            >=1.1      && <1.3
+    , template-haskell  >=2.7.0.0  && <2.22
+    , text              >=1.2.3.0  && <1.3  || >=2.0 && <2.2
 
   exposed-modules:  Data.UUID.Types
 

--- a/uuid/CHANGES.md
+++ b/uuid/CHANGES.md
@@ -1,3 +1,8 @@
+1.3.16
+
+- Optimize and refactor functions `toByteString` (3.7x speed increase) and
+  `toASCIIBytes` (20% speed increase).
+
 1.3.15
 
 - Add (Template Haskell) `Lift UUID` instance

--- a/uuid/uuid.cabal
+++ b/uuid/uuid.cabal
@@ -1,6 +1,6 @@
 cabal-version:      1.12
 name:               uuid
-version:            1.3.15
+version:            1.3.16
 x-revision:         3
 copyright:          (c) 2008-2014 Antoine Latter
 author:             Antoine Latter
@@ -46,16 +46,16 @@ source-repository head
 
 library
   build-depends:
-      base             >=4.5      && <5
-    , binary           >=0.5.1.0  && <0.9
-    , bytestring       >=0.9.2.1  && <0.13
-    , cryptohash-md5   >=0.11.100 && <0.12
-    , cryptohash-sha1  >=0.11.100 && <0.12
-    , entropy          >=0.3.7    && <0.5
-    , network-info     >=0.2      && <0.3
-    , random           >=1.1      && <1.3
-    , text             >=1.2.3.0  && <1.3 || >=2.0 && <2.2
-    , time             >=1.4      && <1.13
+      base             >=4.5       && <5
+    , binary           >=0.5.1.0   && <0.9
+    , bytestring       >=0.10.2.0  && <0.13
+    , cryptohash-md5   >=0.11.100  && <0.12
+    , cryptohash-sha1  >=0.11.100  && <0.12
+    , entropy          >=0.3.7     && <0.5
+    , network-info     >=0.2       && <0.3
+    , random           >=1.1       && <1.3
+    , text             >=1.2.3.0   && <1.3 || >=2.0 && <2.2
+    , time             >=1.4       && <1.13
 
   -- strict dependency on uuid-types,
   -- as we re-rexport datatype, thus leak instances etc.


### PR DESCRIPTION
This PR leverages the bytestring fixed-length builders to simplify and speed up the conversions. The re-implementation of `toASCIIBytes` is now more high-level and safe.

I bumped the bytestring dependency lower bound to the version that introduces  `Data.ByteString.Builder.Prim`. It was released in 2012, so that is plenty of backwards compatibility.

Here are benchmarks on MacBook M1 Max:

Before
```
benchmarking conversion/toASCIIBytes
time                 34.23 ns   (34.16 ns .. 34.35 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 34.21 ns   (34.18 ns .. 34.29 ns)
std dev              169.2 ps   (40.23 ps .. 290.2 ps)

benchmarking conversion/toByteString
time                 74.16 ns   (73.96 ns .. 74.43 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 74.07 ns   (73.98 ns .. 74.25 ns)
std dev              398.7 ps   (176.1 ps .. 649.3 ps)

```

After
```
benchmarking conversion/toASCIIBytes
time                 28.61 ns   (28.59 ns .. 28.63 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 28.62 ns   (28.60 ns .. 28.65 ns)
std dev              56.85 ps   (26.42 ps .. 117.3 ps)

benchmarking conversion/toByteString
time                 20.87 ns   (20.81 ns .. 20.96 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 20.94 ns   (20.89 ns .. 21.01 ns)
std dev              200.6 ps   (144.6 ps .. 259.8 ps)
```