### PR TITLE
ghc 9.14.1 support

### DIFF
--- a/.github/workflows/haskell-ci-bench.yml
+++ b/.github/workflows/haskell-ci-bench.yml
@@ -14,6 +14,7 @@
 #
 name: Benchmarks
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -23,15 +24,24 @@ on:
 jobs:
   linux:
     name: Benchmarks - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
-    timeout-minutes:
-      60
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
     container:
       image: buildpack-deps:jammy
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.1
+            compilerKind: ghc
+            compilerVersion: 9.14.1
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.12.2
+            compilerKind: ghc
+            compilerVersion: 9.12.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.10.1
             compilerKind: ghc
             compilerVersion: 9.10.1
@@ -84,10 +94,10 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.50.2/x86_64-linux-ghcup-0.1.50.2 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -105,7 +115,7 @@ jobs:
           echo "HC=$HC" >> "$GITHUB_ENV"
           echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
           echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"

--- a/.github/workflows/haskell-ci-bench.yml
+++ b/.github/workflows/haskell-ci-bench.yml
@@ -8,24 +8,29 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20240702
+# version: 0.19.20260209
 #
-# REGENDATA ("0.19.20240702",["github","--project","cabal.bench.project","-o",".github/workflows/haskell-ci-bench.yml","--github-action-name","Benchmarks"])
+# REGENDATA ("0.19.20260209",["github","--project","cabal.bench.project","-o",".github/workflows/haskell-ci-bench.yml","--github-action-name","Benchmarks"])
 #
 name: Benchmarks
 on:
-  workflow_dispatch:
   push:
     branches:
       - master
   pull_request:
     branches:
       - master
+  merge_group:
+    branches:
+      - master
+  workflow_dispatch:
+    {}
 jobs:
   linux:
     name: Benchmarks - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes:
+      60
     container:
       image: buildpack-deps:jammy
     continue-on-error: ${{ matrix.allow-failure }}
@@ -89,15 +94,29 @@ jobs:
             allow-failure: false
       fail-fast: false
     steps:
-      - name: apt
+      - name: apt-get install
         run: |
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+      - name: Install GHCup
+        run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.50.2/x86_64-linux-ghcup-0.1.50.2 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.50.1/x86_64-linux-ghcup-0.1.50.1 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
-          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+      - name: Install cabal-install
+        run: |
           "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+      - name: Install GHC (GHCup)
+        if: matrix.setup-method == 'ghcup'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -108,21 +127,12 @@ jobs:
           echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
-          HCDIR=/opt/$HCKIND/$HCVER
-          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
-          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -172,7 +182,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -197,7 +207,11 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_uuid_bench}" >> cabal.project
           echo "package uuid-bench" >> cabal.project
-          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package uuid-bench" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package uuid-bench" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(uuid-bench)$/; }' >> cabal.project.local
@@ -244,8 +258,8 @@ jobs:
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='random==1.2.*' --dependencies-only -j2 all
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='random==1.2.*' all
       - name: save cache
-        uses: actions/cache/save@v4
         if: always()
+        uses: actions/cache/save@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,24 +8,29 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250330
+# version: 0.19.20260209
 #
-# REGENDATA ("0.19.20250330",["github","cabal.project"])
+# REGENDATA ("0.19.20260209",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
-  workflow_dispatch:
   push:
     branches:
       - master
   pull_request:
     branches:
       - master
+  merge_group:
+    branches:
+      - master
+  workflow_dispatch:
+    {}
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes:
+      60
     container:
       image: buildpack-deps:jammy
     continue-on-error: ${{ matrix.allow-failure }}
@@ -96,7 +101,7 @@ jobs:
       - name: Install GHCup
         run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.50.2/x86_64-linux-ghcup-0.1.50.2 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.50.1/x86_64-linux-ghcup-0.1.50.1 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
@@ -177,7 +182,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -206,9 +211,17 @@ jobs:
           echo "packages: ${PKGDIR_uuid_types}" >> cabal.project
           echo "packages: ${PKGDIR_uuid}" >> cabal.project
           echo "package uuid-types" >> cabal.project
-          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project
           echo "package uuid" >> cabal.project
-          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package uuid-types" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package uuid" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package uuid-types" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package uuid" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(uuid|uuid-types)$/; }' >> cabal.project.local

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -14,6 +14,7 @@
 #
 name: Haskell-CI
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -24,14 +25,18 @@ jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-24.04
-    timeout-minutes:
-      60
+    timeout-minutes: 60
     container:
       image: buildpack-deps:jammy
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.1
+            compilerKind: ghc
+            compilerVersion: 9.14.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.12.2
             compilerKind: ghc
             compilerVersion: 9.12.2
@@ -91,12 +96,12 @@ jobs:
       - name: Install GHCup
         run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.50.1/x86_64-linux-ghcup-0.1.50.1 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.50.2/x86_64-linux-ghcup-0.1.50.2 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.1.1-p1 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.1.1-p1 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |

--- a/uuid-bench/uuid-bench.cabal
+++ b/uuid-bench/uuid-bench.cabal
@@ -102,7 +102,7 @@ benchmark uuid-types-benchmark
 
   -- deps w/o inherited constraints
   build-depends:
-      containers            >=0.5   && <0.8
+      containers            >=0.5   && <0.9
     , criterion             >=1.5   && <1.7
     , unordered-containers  >=0.2.7 && <0.3
 

--- a/uuid-bench/uuid-bench.cabal
+++ b/uuid-bench/uuid-bench.cabal
@@ -23,6 +23,8 @@ tested-with:
    || ==9.6.6
    || ==9.8.2
    || ==9.10.1
+   || ==9.12.2
+   || ==9.14.1
 
 synopsis:      UUID benchmarks
 description:
@@ -50,9 +52,9 @@ library
     , hashable          >=1.4.4.0  && <1.6
     , network-info      >=0.2      && <0.3
     , random            >=1.2.1.2  && <1.3
-    , template-haskell  >=2.14.0.0 && <2.23
+    , template-haskell  >=2.14.0.0 && <2.25
     , text              >=1.2.3.0  && <1.3  || >=2.0 && <2.2
-    , time              >=1.4      && <1.13
+    , time              >=1.4      && <1.16
 
   -- uuid modules
   exposed-modules:
@@ -106,7 +108,7 @@ benchmark uuid-types-benchmark
 
 benchmark uuid-benchmark
   type:               exitcode-stdio-1.0
-  main-is:            uuid-benchmark.hs 
+  main-is:            uuid-benchmark.hs
   hs-source-dirs:     bench
   default-language:   Haskell2010
   default-extensions:

--- a/uuid-types/src/Data/UUID/Types/Internal.hs
+++ b/uuid-types/src/Data/UUID/Types/Internal.hs
@@ -46,13 +46,11 @@ module Data.UUID.Types.Internal
 
 import           Prelude                          hiding (null)
 
-import           Control.Applicative              ((<*>))
 import           Control.DeepSeq                  (NFData (..))
 import           Control.Monad                    (guard, liftM2)
 import           Data.Bits
 import           Data.Char
 import           Data.Data
-import           Data.Functor                     ((<$>))
 import           Data.Hashable
 import           Data.List                        (elemIndices)
 import           Foreign.Ptr                      (Ptr)

--- a/uuid-types/uuid-types.cabal
+++ b/uuid-types/uuid-types.cabal
@@ -23,6 +23,7 @@ tested-with:
    || ==9.8.4
    || ==9.10.1
    || ==9.12.2
+   || ==9.14.1
 
 synopsis:           Type definitions for Universally Unique Identifiers
 description:
@@ -52,7 +53,7 @@ library
     , deepseq           >=1.4.4.0  && <1.6
     , hashable          >=1.4.4.0  && <1.6
     , random            >=1.2.1.2  && <1.4
-    , template-haskell  >=2.14.0.0 && <2.24
+    , template-haskell  >=2.14.0.0 && <2.3
     , text              >=1.2.3.0  && <1.3  || >=2.0 && <2.2
 
   exposed-modules:  Data.UUID.Types

--- a/uuid-types/uuid-types.cabal
+++ b/uuid-types/uuid-types.cabal
@@ -53,7 +53,7 @@ library
     , deepseq           >=1.4.4.0  && <1.6
     , hashable          >=1.4.4.0  && <1.6
     , random            >=1.2.1.2  && <1.4
-    , template-haskell  >=2.14.0.0 && <2.3
+    , template-haskell  >=2.14.0.0 && <2.25
     , text              >=1.2.3.0  && <1.3  || >=2.0 && <2.2
 
   exposed-modules:  Data.UUID.Types

--- a/uuid-types/uuid-types.cabal
+++ b/uuid-types/uuid-types.cabal
@@ -84,7 +84,6 @@ test-suite testuuid
       base
     , binary
     , bytestring
-    , template-haskell
     , uuid-types
 
   -- deps w/o inherited constraints

--- a/uuid/src/Data/UUID/Named.hs
+++ b/uuid/src/Data/UUID/Named.hs
@@ -28,7 +28,6 @@ module Data.UUID.Named
 
 import Data.UUID.Types.Internal
 
-import Control.Applicative ((<*>),(<$>))
 import Data.Binary.Get (runGet, getWord32be)
 import Data.Maybe
 import Data.Word (Word8)

--- a/uuid/src/Data/UUID/V1.hs
+++ b/uuid/src/Data/UUID/V1.hs
@@ -31,7 +31,6 @@ import Data.Maybe
 import Data.Time
 import Data.Word
 
-import Control.Applicative ((<$>),(<*>))
 import Control.Concurrent.MVar
 import System.IO.Unsafe
 

--- a/uuid/uuid.cabal
+++ b/uuid/uuid.cabal
@@ -20,6 +20,7 @@ tested-with:
    || ==9.8.4
    || ==9.10.1
    || ==9.12.2
+   || ==9.14.1
 
 synopsis:
   For creating, comparing, parsing and printing Universally Unique Identifiers

--- a/uuid/uuid.cabal
+++ b/uuid/uuid.cabal
@@ -50,7 +50,6 @@ library
     , entropy          >=0.3.7    && <0.5
     , network-info     >=0.2      && <0.3
     , random           >=1.2.1.2  && <1.4
-    , text             >=1.2.3.0  && <1.3  || >=2.0 && <2.2
     , time             >=1.4      && <1.16
 
   -- strict dependency on uuid-types,
@@ -87,7 +86,6 @@ test-suite testuuid
   build-depends:
       base
     , bytestring
-    , random
     , uuid
 
   -- deps w/o inherited constraints

--- a/uuid/uuid.cabal
+++ b/uuid/uuid.cabal
@@ -51,7 +51,7 @@ library
     , network-info     >=0.2      && <0.3
     , random           >=1.2.1.2  && <1.4
     , text             >=1.2.3.0  && <1.3  || >=2.0 && <2.2
-    , time             >=1.4      && <1.2
+    , time             >=1.4      && <1.16
 
   -- strict dependency on uuid-types,
   -- as we re-rexport datatype, thus leak instances etc.

--- a/uuid/uuid.cabal
+++ b/uuid/uuid.cabal
@@ -51,7 +51,7 @@ library
     , network-info     >=0.2      && <0.3
     , random           >=1.2.1.2  && <1.4
     , text             >=1.2.3.0  && <1.3  || >=2.0 && <2.2
-    , time             >=1.4      && <1.15
+    , time             >=1.4      && <1.2
 
   -- strict dependency on uuid-types,
   -- as we re-rexport datatype, thus leak instances etc.


### PR DESCRIPTION
A number of small changes that enable ghc 9.14.1 support:

* bumped selected packages
  * template-haskell
  * time
  * containers
* updated ci
  * new ghcup
  * new cabal
  * ghc 9.14.1
* updated benchmark ci
  * new ubuntu (there seem to be no runners available for the old version)
  * new ghcup
  * new cabal
  * ghc 9.12.2
  * ghc 9.14.1

I can't run the ci workflow here without an approval but here is a green ci run from my fork: https://github.com/PiotrJustyna/uuid/actions/runs/21983807149

My [ci bench run](https://github.com/PiotrJustyna/uuid/actions/runs/21753420163/job/62757017812) fails for ghc 9.14.1 as a result of this repository not supporting base 4.22: https://github.com/haskellari/microstache/issues/45 (issue already raised in January) and I see the same maintainer, so I just upvoted the issue.

Thank you all.